### PR TITLE
Add PJ64 3.0.x to known emulators

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -26,6 +26,7 @@ fn find_emulator() -> Result<PathBuf> {
         "/usr/bin/mupen64plus",
         "/usr/bin/retroarch",
         "C:\\Program Files (x86)\\Project64 2.3\\Project64.exe",
+        "C:\\Program Files (x86)\\Project64 3.0\\Project64.exe",
     ];
 
     for path in EMULATOR_PATHS {


### PR DESCRIPTION
This PR fixes #45, though this doesn't fix the underlying issue of version differences. If PJ64 moves to 3.1.x in the future, that will need to be added as well.