### PR TITLE
docs: fix outdated install reference

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -82,7 +82,7 @@ sign it.
 If you already have Rust installed, you can install Merlon using Cargo:
 
 ```console
-$ cargo install merlon
+$ cargo install --git https://github.com/nanaian/merlon
 ```
 
 ### Verifying the installation


### PR DESCRIPTION
The current "Getting Started" docs reference the version of Merlon hosted at crates.io, which is outdated and throws this error:
```
bash: install.sh: No such file or directory
Error: failed to initialise package

Caused by:
    failed to run decomp install.sh
```
when running `merlon init --baserom [...]`.

This quick commit redirects cargo to use merlon's repository hosted at github.